### PR TITLE
Fix Vue Bootstrap Popover import.

### DIFF
--- a/dist/click-confirm.common.js
+++ b/dist/click-confirm.common.js
@@ -4,7 +4,7 @@ Object.defineProperty(exports, '__esModule', { value: true });
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var bPopover = _interopDefault(require('bootstrap-vue/es/components/popover/popover'));
+var bPopover = _interopDefault(require('bootstrap-vue'));
 
 var messagesDefault = {
     title: 'Are you sure?',


### PR DESCRIPTION
At some point Vue Bootstrap as changed and the import should be `import { BPopover } from 'bootstrap-vue'` rather than `import { BPopover } from 'bootstrap-vue/es/components/popover/popover'` this pull request fixes that.

Fixes: https://github.com/SirLamer/click-confirm/issues/14